### PR TITLE
Add non-mandatory sftp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ See also: http://wiki.hetzner.de/index.php/Backup_Space_SSH_Keys
 ### Usage
 Try the plugin at the command line like this:
 ```
-./check_sftpsace.sh -h [host] -u [user] -w [warn] -c [crit]
+./check_sftpsace.sh -h [host] -u [user] [ -o sftpOpt ] -w [warn] -c [crit]
 ```
 
 Replace the variables:
 * __host__: sftp host to connect to
 * __user__: username at the sftp server
+* __sftpOpt__: extra sftp option, e.g. `port=23`
 * __warn__: percentage of needed minimum free space before warning
 * __crit__: percentage of needed minimum free space before critical
 
@@ -48,6 +49,10 @@ object CheckCommand "sftpspace" {
     "-u" = {
       "required" = true
       "value" = "$ss_user$"
+    }
+    "-o" = {
+      "required" = false
+      "value" = "$ss_sftpOpt$"
     }
     "-w" = {
       "required" = true

--- a/check_sftpspace.sh
+++ b/check_sftpspace.sh
@@ -8,24 +8,26 @@
 # Copyright (c) 2017 Jan Vonde <mail@jan-von.de>
 #
 #
-# Usage: ./check_sftpsace.sh -h [host] -u [user] -w [warn] -c [crit]
+# Usage: ./check_sftpsace.sh -h [host] -u [user] [ -o sftpOption ] -w [warn] -c [crit]
 #
 #
 # Changelog:
 #   2015-12-07: initial Version
 #   2017-01-01: remove unused comments, fix WARN and CRIT, add perfdata
+#   2020-07-30: add -o option
 #
 # For more information visit https://github.com/janvonde/check_sftpspace
 #####
 
 
-USAGE="Usage: check_sftpsace.sh -h [host] -u [user] -w [warn] -c [crit]"
+USAGE="Usage: check_sftpsace.sh -h [host] -u [user] [ -o sftpOption] -w [warn] -c [crit]"
 
-if [ $# == 8 ]; then
-	while getopts "h:u:w:c:"  OPCOES; do
+if [ $# -ge 8 ]; then
+	while getopts "h:u:o::w:c:"  OPCOES; do
 		case $OPCOES in
 			h ) SFTPHOST=$OPTARG;;
 			u ) SFTPUSER=$OPTARG;;
+			o ) SFTPOPTN=$OPTARG;;
 			w ) WARN=$OPTARG;;
 			c ) CRIT=$OPTARG;;
 			? ) echo $USAGE
@@ -42,10 +44,12 @@ fi
 ## error handling
 type -P sftp &>/dev/null || { echo "ERROR: sftp is required but seems not to be installed.  Aborting." >&2; exit 1; }
 
+## sftp extra opt
+[ -z $SFTPOPTN ] && SFTPOPTN="port=22"
 
 
 ## get info and store
-RESULT=$(echo "df -h" | sftp ${SFTPUSER}@${SFTPHOST} 2>&1 | tail -1 | column -t)
+RESULT=$(echo "df -h" | sftp -o $SFTPOPTN ${SFTPUSER}@${SFTPHOST} 2>&1 | tail -1 | column -t)
 read TOTAL USED AVAILABLE ROOT PERCENT <<< $RESULT
 PERCENT=$(expr 100 - ${PERCENT/\%/})
 
@@ -63,6 +67,6 @@ if [ ${PERCENT} -lt ${WARN} ]; then
 fi
 
 
-echo "OK - ${AVAILABLE} free space: (${USED} out of ${TOTAL} or ${PERCENT}% used) |sftp_disk_usage=${USED};${WARN};${CRIT};0;${TOTAL}"
+echo "OK - ${AVAILABLE} free space: (${USED} out of ${TOTAL} or ${PERCENT}% free) |sftp_disk_usage=${USED};${WARN};${CRIT};0;${TOTAL}"
 exit 0
 


### PR DESCRIPTION
Hello !

I've found your script `check_sftpspace.sh` very useful. Since I am using an Hetzner StorageBox, I needed to access it on port 23 and not 22, so I've added an extra `-o sftpOption` non mandatory option.
If the option is not present, then a default `port=22` option is set within the command.

Hope you'll find this useful.

BR, Michel